### PR TITLE
feat: widget gates + spawn-path consolidation + arch contract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,139 +1,49 @@
+version: '3.8'
+
 services:
-  # --- Media Server ---
-  plex:
-    image: lscr.io/linuxserver/plex:latest
-    container_name: plex
-    network_mode: host
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - VERSION=docker
-      - PLEX_CLAIM= #optional
-    volumes:
-      - ./config/plex:/config
-      - /9tb/media/tvshows:/tv
-      - /9tb/media/movies:/movies
-    restart: unless-stopped
-
-  # --- Media Management ---
-  sonarr:
-    image: lscr.io/linuxserver/sonarr:latest
-    container_name: sonarr
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Los_Angeles
-    volumes:
-      - ./config/sonarr:/config
-      - /9tb/media/tvshows:/tv
-      - /9tb/torrents:/downloads
+  titan:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: titan-gateway
     ports:
-      - 8989:8989
-    depends_on:
-      - qbittorrent
-      - prowlarr
-    restart: unless-stopped
-
-  radarr:
-    image: lscr.io/linuxserver/radarr:latest
-    container_name: radarr
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Los_Angeles
+      - "48420:48420"
     volumes:
-      - ./config/radarr:/config
-      - /9tb/media/movies:/movies
-      - /9tb/torrents:/downloads
-    ports:
-      - 7878:7878
-    depends_on:
-      - qbittorrent
-      - prowlarr
-    restart: unless-stopped
-
-  prowlarr:
-    image: lscr.io/linuxserver/prowlarr:latest
-    container_name: prowlarr
+      - titan-data:/home/titan/.titan
+      # Optional: Mount local config/skills directory
+      # - ./config:/home/titan/.titan/config
+      # - ./skills:/home/titan/.titan/skills
     environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Los_Angeles
-    volumes:
-      - ./config/prowlarr:/config
-    ports:
-      - 9696:9696
+      - NODE_ENV=production
+      - TITAN_HOME=/home/titan/.titan
+      # Gateway binding (0.0.0.0 for container access)
+      - TITAN_GATEWAY_HOST=0.0.0.0
+      # GPU support (uncomment deploy section below for GPU)
+      # - OLLAMA_HOST=http://host.docker.internal:11434
+      # API Keys (use docker secrets or .env file in production):
+      # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      # - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # - GOOGLE_API_KEY=${GOOGLE_API_KEY}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:48420/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    # GPU passthrough (NVIDIA) — uncomment when GPU is available
+    # See docker-compose.nvidia.yml for full GPU-accelerated setup
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]
+    # Extra hosts for Ollama on host machine
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway"
 
-  jackett:
-    image: lscr.io/linuxserver/jackett:latest
-    container_name: jackett
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Los_Angeles
-    volumes:
-      - ./config/jackett:/config
-      - /9tb/torrents/blackhole:/downloads
-    ports:
-      - 9117:9117
-    restart: unless-stopped
-
-  flaresolverr:
-    image: flaresolverr/flaresolverr:latest
-    container_name: flaresolverr
-    environment:
-      - LOG_LEVEL=info
-      - TZ=America/Los_Angeles
-    ports:
-      - 8191:8191
-    restart: unless-stopped
-
-  # --- Downloader ---
-  qbittorrent:
-    image: lscr.io/linuxserver/qbittorrent:latest
-    container_name: qbittorrent
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Los_Angeles
-      - WEBUI_PORT=8080
-    volumes:
-      - ./config/qbittorrent:/config
-      - /9tb/torrents:/downloads
-    ports:
-      - 8080:8080
-      - 6881:6881
-      - 6881:6881/udp
-    restart: unless-stopped
-
-  # --- AI Controller ---
-  # This is a custom service we will build
-  ai-media-controller:
-    build: ./data/ai-agent
-    container_name: ai-media-controller
-    environment:
-      - SONARR_URL=http://sonarr:8989
-      - RADARR_URL=http://radarr:7878
-      - SONARR_API_KEY=ef554ebb60314d3c94e7c465f45eab74
-      - RADARR_API_KEY=b8ded7657c1c4d10b4a5051485b2acb2
-      - TMDB_API_KEY=1fdee3d018c7af868ad62d2657d9ccb7
-    volumes:
-      - ./data/ai-agent:/app
-      - ./data/logs:/app/logs
-    depends_on:
-      - sonarr
-      - radarr
-    restart: unless-stopped
-
-  dashboard:
-    build: ./dashboard
-    container_name: dashboard
-    environment:
-      - QBIT_URL=http://qbittorrent:8080
-    volumes:
-      - ./data/logs:/app/logs
-      - /var/run/docker.sock:/var/run/docker.sock
-    ports:
-      - 3000:3000
-    restart: unless-stopped
+volumes:
+  titan-data:
+    driver: local

--- a/docs/SECURITY-AUDIT-2026-04-28.md
+++ b/docs/SECURITY-AUDIT-2026-04-28.md
@@ -1,0 +1,73 @@
+# Security audit — 2026-04-28
+
+> Snapshot of the npm vulnerability landscape after the v5.4.x CI cleanup.
+> What's already fixed, what's left, and which fixes are safe to land vs.
+> need a careful review.
+
+## Already on `main` at patched versions
+
+These were lifted by routine Dependabot bumps during the v5.4.x sweep:
+
+| Package | Direct? | Patched | On `main` |
+|---|---|---|---|
+| protobufjs | direct | 7.5.5 (was: critical RCE) | ^7.5.5 ✓ |
+| esbuild | direct | 0.25.0 | ^0.25.0 ✓ |
+| vite | direct | 6.4.2 | ^6.4.2 ✓ |
+| langsmith | direct | 0.5.19 | ^0.5.19 ✓ |
+| uuid | direct | 14.0.0 | ^14.0.0 ✓ (PR #47) |
+
+The "1 critical / 1 high / 15 moderate" GitHub Security tab badge is
+stale — Dependabot keeps an alert open per CVE per package, not per
+vulnerable installation. Once a `npm install` runs and writes the new
+`package-lock.json` to a branch that Dependabot scans, those advisories
+get auto-resolved.
+
+## Remaining work
+
+`npm audit` against the current `main` reports 6 moderate vulns, all
+in our **direct** dependencies — fixed by version bumps, not by lock
+regeneration:
+
+| Package | Severity | Patched | Bump shape | Risk |
+|---|---|---|---|---|
+| matrix-js-sdk | moderate | 22.0.0 | major (we're at 21.x) | low — Matrix channel only |
+| @langchain/core | moderate | 3.0.5 | minor | low |
+| @langchain/openai | moderate | auto | minor | low |
+| @browserbasehq/stagehand | moderate | 3.0.5 | major | medium — browsing layer |
+| node-cron | moderate | 4.2.1 | major (we're at 3.x) | medium — cron syntax / TZ change |
+| postcss (UI transitive) | moderate | 8.5.10 | flushed by next vite bump or `overrides` | low |
+
+## Recommended sequencing
+
+1. **Single safe-bump PR:** `matrix-js-sdk@^22`, `@langchain/core@^3.0.5`,
+   `@langchain/openai@latest-minor`, `@browserbasehq/stagehand@^3` — all
+   together so the lock regenerates once. Run `tests/matrix.test.ts`,
+   `tests/langgraph.test.ts`, and any browsing/Stagehand integration
+   tests before merging.
+2. **`node-cron` 3→4 PR (separate):** read the upstream changelog. The
+   cron string parser tightened in v4 — any goal/recipe with a non-
+   strict expression will silently stop firing. Audit `~/.titan/`
+   user data + builtin cron defaults before merging.
+3. **`overrides` block for UI postcss:** add `"overrides": { "postcss":
+   "^8.5.12" }` to root `package.json`. Cleanest path until vite ships
+   a postcss-9 cascade.
+
+## Why this isn't `npm audit fix`
+
+`npm audit fix` rewrites the lockfile against transitive resolutions
+without distinguishing which version constraints are "ours" vs
+"inherited." The peer-dep grouping bug in v5.4.0 (vitest /
+@vitest/coverage-v8 split into prod vs dev deps, then ERESOLVE on
+`npm ci`) was that exact failure mode. Reviewable per-package PRs
+keep lock churn auditable.
+
+## How to verify any fix
+
+```sh
+cd ~/titan-publish               # or fresh clone
+git pull
+npm install                      # regenerates package-lock.json
+npm audit                        # should drop to 0 after the safe-bump PR
+npm test -- tests/matrix.test.ts # for matrix-js-sdk
+npm test -- tests/cron.test.ts   # for node-cron
+```

--- a/src/agent/swarm.ts
+++ b/src/agent/swarm.ts
@@ -1,13 +1,22 @@
 /**
  * TITAN — Kimi Swarm Architecture
- * 
- * Intercepts requests meant for kimi-k2.5:cloud and routes them through specialized Sub-Agents.
- * By breaking the 23-tool monolith into small 3-4 tool domain chunks, we prevent Kimi from
- * suffering context collapse and timeouts.
+ *
+ * Intercepts requests meant for kimi-k2.5:cloud and routes them through
+ * specialized Sub-Agents. By breaking the 23-tool monolith into small 3-4
+ * tool domain chunks, we prevent Kimi from suffering context collapse and
+ * timeouts.
+ *
+ * v5.4.x note (Phase B consolidation): `runSubAgent` used to host its own
+ * mini agent loop with a separate `chat()` + `executeTools()` cycle. That
+ * bypassed every cross-cutting layer in `commandPost` / `budgetEnforcer` /
+ * `guardrails` — sub-agents went off the books. It now delegates to the
+ * canonical `spawnSubAgent` with a domain-restricted tool allowlist and a
+ * 3-round cap. The Swarm Router's external surface (the
+ * `delegate_to_X_agent` tools) is unchanged.
  */
-import { chat } from '../providers/router.js';
-import { executeTools, getToolDefinitions } from './toolRunner.js';
-import type { ChatMessage, ToolDefinition } from '../providers/base.js';
+import { spawnSubAgent } from './subAgent.js';
+import { getToolDefinitions } from './toolRunner.js';
+import type { ToolDefinition } from '../providers/base.js';
 import logger from '../utils/logger.js';
 
 const COMPONENT = 'Swarm';
@@ -104,9 +113,22 @@ function getDomainTools(domain: Domain): ToolDefinition[] {
     return allTools.filter(t => (domainMap[t.function.name] || 'file') === domain);
 }
 
-/** 
- * Spawns an ephemeral Sub-Agent with a restricted toolset. 
- * This is executed sequentially by the Main Director.
+/**
+ * Spawn a domain-restricted ephemeral sub-agent for the Swarm Router.
+ *
+ * v5.4.x: this is now a thin shim over `spawnSubAgent`. The previous
+ * implementation ran its own `chat()` + `executeTools()` loop, which left
+ * the spawned agent invisible to the governance overlay (Command Post,
+ * BudgetEnforcer, audit log). All sub-agent execution now flows through
+ * the canonical path.
+ *
+ * Behavior preserved:
+ *   - Tool surface restricted to the requested domain (file/web/system/memory).
+ *   - 3-round cap (matched the original mini-loop ceiling).
+ *   - Output prefixed with `[Sub-Agent Result / Domain: <domain>]` so
+ *     callers' string parsing still works.
+ *   - Errors return a string starting with `Sub-Agent encountered an error:`
+ *     rather than throwing, matching the old contract.
  */
 export async function runSubAgent(
     domain: Domain,
@@ -116,60 +138,31 @@ export async function runSubAgent(
     logger.info(COMPONENT, `[Swarm] Spawning ${domain.toUpperCase()} Sub-Agent to handle: "${instruction.slice(0, 50)}..."`);
 
     const domainTools = getDomainTools(domain);
+    const toolNames = domainTools.map(t => t.function.name);
 
-    // Mini agent loop (max 3 rounds)
-    const messages: ChatMessage[] = [
-        { role: 'system', content: `You are the ${domain.toUpperCase()} Sub-Agent of TITAN.\nYour ONLY job is to execute the tools necessary to fulfill this instruction:\n\n${instruction}\n\nReturn a final text summary of the results.` },
-        { role: 'user', content: instruction }
-    ];
+    try {
+        const result = await spawnSubAgent({
+            // The `name` field becomes the agent's identifier in logs and
+            // governance feeds — keep it descriptive of the swarm domain.
+            name: `swarm-${domain}`,
+            task: instruction,
+            model,
+            // Match the historical 3-round budget exactly. The driver has
+            // its own depth-aware reduction on top of this; see subAgent.ts
+            // ~line 408.
+            maxRounds: 3,
+            // `spawnSubAgent` interprets `tools` as an allowlist of tool
+            // *names*. Empty list → no tools are presented to the model
+            // (matches the old `tools: domainTools.length > 0 ? ... :
+            // undefined` semantics, since `spawnSubAgent` skips the tool
+            // header when the resolved set is empty).
+            tools: toolNames,
+        });
 
-    let finalContent = '';
-
-    for (let round = 0; round < 3; round++) {
-        logger.debug(COMPONENT, `[Sub-Agent ${domain}] Round ${round + 1} with ${domainTools.length} tools`);
-
-        try {
-            const response = await chat({
-                model,
-                messages,
-                tools: domainTools.length > 0 ? domainTools : undefined,
-                maxTokens: 4096,
-                temperature: 0.2, // Low temp for strictly clinical tool execution
-            });
-
-            if (!response.toolCalls || response.toolCalls.length === 0) {
-                finalContent = response.content || 'Task completed silently.';
-                break;
-            }
-
-            messages.push({
-                role: 'assistant',
-                content: response.content || '',
-                toolCalls: response.toolCalls,
-            });
-
-            const toolResults = await executeTools(response.toolCalls);
-
-            for (const result of toolResults) {
-                messages.push({
-                    role: 'tool',
-                    // Include name — Gemini's Ollama adapter rejects
-                    // function_response with empty name (HTTP 400).
-                    name: result.name,
-                    content: result.content,
-                    toolCallId: result.toolCallId,
-                });
-            }
-
-            if (round === 2) {
-                finalContent = "Max sub-agent rounds reached. Partial results returned.";
-            }
-
-        } catch (e) {
-            logger.error(COMPONENT, `[Sub-Agent ${domain}] Error: ${(e as Error).message}`);
-            return `Sub-Agent encountered an error: ${(e as Error).message}`;
-        }
+        const finalContent = result?.content || 'Task completed silently.';
+        return `[Sub-Agent Result / Domain: ${domain}]\n${finalContent}`;
+    } catch (e) {
+        logger.error(COMPONENT, `[Sub-Agent ${domain}] Error: ${(e as Error).message}`);
+        return `Sub-Agent encountered an error: ${(e as Error).message}`;
     }
-
-    return `[Sub-Agent Result / Domain: ${domain}]\n${finalContent}`;
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -3341,6 +3341,57 @@ export async function startGateway(options?: { port?: number; host?: string; ver
         { pattern: /\b(?:paperclip|sidecars?|helpers?)\b/i, source: 'system:paperclip', name: 'Paperclip', w: 6, h: 5 },
         { pattern: /\b(?:tests?|flaky|failing|coverage|eval)\b/i, source: 'system:eval', name: 'Test Lab', w: 6, h: 6 },
     ];
+    // ── Widget-clear fast-path ─────────────────────────────────────
+    // "clear the canvas" / "wipe all widgets" — emit _____widget_clear
+    // directly. Must precede the per-widget shortcut matcher; otherwise
+    // "clear" can collide with widget name patterns.
+    //
+    // The regex requires the destruction verb followed by a SPACE (not a
+    // hyphen, so "clear-style widget" is not matched) and an explicit
+    // target noun (canvas/widgets/space/board/all). The "remove/delete +
+    // all/every/each" branch handles "remove all widgets" phrasings.
+    const widgetClearPattern = /\b(?:clear|wipe|reset|empty)\s+(?:.*\b)?(?:canvas|widgets?|space|board|all)\b|\b(?:remove|delete)\s+(?:all|every|each)\b/i;
+    if (widgetClearPattern.test(content)) {
+        const gateText = `_____widget_clear\n{}`;
+        const responseText = `Clearing the canvas.`;
+        titanRequestsTotal.increment({ channel, status: 'ok' });
+        if (req.headers.accept === 'text/event-stream') {
+            res.setHeader('Content-Type', 'text/event-stream');
+            res.flushHeaders();
+            res.write(`event: token\ndata: ${JSON.stringify({ text: responseText })}\n\n`);
+            res.write(`event: token\ndata: ${JSON.stringify({ text: '\n\n' + gateText })}\n\n`);
+            res.write(`event: done\ndata: ${JSON.stringify({ content: responseText + '\n\n' + gateText, sessionId: requestedSessionId || null, durationMs: 0, toolsUsed: [] })}\n\n`);
+            res.end();
+        } else {
+            res.json({ content: responseText + '\n\n' + gateText, sessionId: requestedSessionId || null, toolsUsed: [], model: 'system', durationMs: 0 });
+        }
+        return;
+    }
+
+    // ── Widget-remove fast-path ────────────────────────────────────
+    // "remove the VRAM widget" / "close the cron panel" / "delete the
+    // backup widget". Match a remove-verb plus a known widget pattern.
+    const widgetRemoveVerb = /\b(?:remove|delete|close|kill|hide)\b/i;
+    if (widgetRemoveVerb.test(content)) {
+        const targetShortcut = systemWidgetShortcuts.find(s => s.pattern.test(content));
+        if (targetShortcut) {
+            const gateText = `_____widget_remove\n{ "source": "${targetShortcut.source}" }`;
+            const responseText = `Removing the **${targetShortcut.name}** widget from your canvas.`;
+            titanRequestsTotal.increment({ channel, status: 'ok' });
+            if (req.headers.accept === 'text/event-stream') {
+                res.setHeader('Content-Type', 'text/event-stream');
+                res.flushHeaders();
+                res.write(`event: token\ndata: ${JSON.stringify({ text: responseText })}\n\n`);
+                res.write(`event: token\ndata: ${JSON.stringify({ text: '\n\n' + gateText })}\n\n`);
+                res.write(`event: done\ndata: ${JSON.stringify({ content: responseText + '\n\n' + gateText, sessionId: requestedSessionId || null, durationMs: 0, toolsUsed: [] })}\n\n`);
+                res.end();
+            } else {
+                res.json({ content: responseText + '\n\n' + gateText, sessionId: requestedSessionId || null, toolsUsed: [], model: 'system', durationMs: 0 });
+            }
+            return;
+        }
+    }
+
     const matchedShortcut = systemWidgetShortcuts.find(s => s.pattern.test(content));
     if (matchedShortcut) {
         const gateText = `_____widget\n{ "name": "${matchedShortcut.name}", "format": "system", "source": "${matchedShortcut.source}", "w": ${matchedShortcut.w}, "h": ${matchedShortcut.h} }`;

--- a/tests/architecture-contract.test.ts
+++ b/tests/architecture-contract.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Architecture contract — tests/architecture-contract.test.ts
+ *
+ * Encoded in `docs/AGENT-HIERARCHY.md`. The doc describes a 3-layer agent
+ * hierarchy (loop / delegation / autonomy + governance overlay) and a
+ * 6-subdir contract for `src/agent/`. The contract itself is enforced
+ * here so it doesn't decay into a doc-only convention.
+ *
+ * What this test guards against:
+ *
+ *   1. Re-introduction of duplicate sub-agent spawn paths. v5.4.x
+ *      consolidated three:
+ *        - swarm.runSubAgent — was its own chat()+executeTools() mini-loop;
+ *          now a shim over spawnSubAgent.
+ *        - structuredSpawn.structuredSpawn — kept (it's a JSON-tail wrapper,
+ *          not a parallel implementation; it calls spawnSubAgent internally).
+ *        - orchestrator inline chat() with 'You are X' system prompts —
+ *          banned.
+ *      The single canonical spawn point is `spawnSubAgent` in
+ *      `src/agent/subAgent.ts`.
+ *
+ *   2. Inline specialist system prompts outside `delegation/specialists.ts`.
+ *      Catches the "I'll just do a quick chat({ systemPrompt: 'You are an
+ *      explorer...' })" pattern that's how parallel spawn paths used to
+ *      sneak back in.
+ *
+ *   3. Fragmented swarm-style mini-loops: any new file in src/agent/ that
+ *      runs its own chat()+executeTools()+round-counter loop bypassing
+ *      spawnSubAgent. This is the "I'll just add another orchestrator"
+ *      regression that the cleanup pass eliminated.
+ *
+ * Note: the 6-subdirectory file-organization contract from AGENT-HIERARCHY.md
+ * (loop/delegation/autonomy/governance/self-mod/tooling) is NOT enforced
+ * here yet — that reorg is queued as a dedicated worktree task because
+ * it touches 100+ files. When it lands, add a directory check to this
+ * suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, '..');
+const AGENT_DIR = join(REPO_ROOT, 'src/agent');
+
+function listAgentFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const stat = statSync(full);
+        if (stat.isDirectory()) {
+            // Skip noisy subdirs (adapters/ has third-party shims with
+            // legitimate inline prompts; tests/ has fixtures).
+            if (entry === 'adapters') continue;
+            out.push(...listAgentFiles(full));
+        } else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+const AGENT_FILES = listAgentFiles(AGENT_DIR);
+
+describe('architecture contract — sub-agent spawn discipline', () => {
+    it('only swarm.ts re-exports / wraps runSubAgent; nothing else defines it', () => {
+        // Any file declaring its own `function runSubAgent` or
+        // `const runSubAgent =` is suspect — likely a parallel mini-loop
+        // sneaking back in. Only swarm.ts is allowed (the shim entry
+        // point).
+        const offenders: string[] = [];
+        for (const file of AGENT_FILES) {
+            if (file.endsWith('/swarm.ts')) continue;
+            const src = readFileSync(file, 'utf8');
+            const declares = /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?function\s+runSubAgent\b|(?:^|\n)\s*(?:export\s+)?const\s+runSubAgent\s*=/m;
+            if (declares.test(src)) {
+                offenders.push(file.replace(REPO_ROOT + '/', ''));
+            }
+        }
+        expect(offenders, `Files declaring their own runSubAgent (only swarm.ts may): ${offenders.join(', ')}`).toEqual([]);
+    });
+
+    it('inline "You are a/an X" specialist prompts only live in the canonical specialist registry', () => {
+        // The pattern that breeds parallel spawn paths: someone writes
+        //   chat({ messages: [{ role: 'system', content: 'You are an
+        //   explorer agent...' }, ...] })
+        // bypassing the specialist registry, governance overlay, and
+        // trace bus. The legitimate home for these strings is exactly
+        // `delegation/specialists.ts` (post-Phase-C) or
+        // `agent/specialists.ts` (pre-reorg).
+        const ALLOWED = new Set([
+            'src/agent/specialists.ts',
+            'src/agent/specialistRouter.ts', // routes to the registry
+            'src/agent/structuredSpawn.ts',  // composes with specialists.systemPromptSuffix
+            'src/agent/subAgent.ts',         // canonical SUB_AGENT_TEMPLATES live here pre-Phase-C
+        ]);
+        // Catch sub-agent-style spawn prompts that bypass the registry.
+        // Specifically: "You are the [Role] sub-agent" / "You are a/an [Role]
+        // agent" / "You are the [Role] Sub-Agent". Generic prompts ("You are
+        // a careful autonomous agent proposing new work" in goalProposer.ts,
+        // "You are a concise task progress assessor" in reflection.ts) are
+        // legitimate chat() callers for their own domain — they don't claim
+        // to be a sub-agent and don't compete with spawnSubAgent.
+        const inlinePromptPattern = /['"`]You are (?:an?|the)\s+\w+\s+(?:sub-?agent|agent\b|Sub-Agent)/i;
+
+        const offenders: string[] = [];
+        for (const file of AGENT_FILES) {
+            const rel = file.replace(REPO_ROOT + '/', '');
+            if (ALLOWED.has(rel)) continue;
+            const src = readFileSync(file, 'utf8');
+            // Strip line/block comments before matching so "// You are an
+            // explorer" in a doc comment doesn't trigger a false positive.
+            const stripped = src
+                .replace(/\/\*[\s\S]*?\*\//g, '')
+                .replace(/(^|[^:])\/\/.*$/gm, '$1');
+            if (inlinePromptPattern.test(stripped)) {
+                offenders.push(rel);
+            }
+        }
+        expect(offenders, `Inline specialist prompts found outside the registry: ${offenders.join(', ')}`).toEqual([]);
+    });
+
+    it('no file outside swarm.ts/subAgent.ts runs a chat()+executeTools() mini-loop', () => {
+        // The canonical agent loop lives in `agentLoop.ts` (the per-turn
+        // user-facing loop) and `subAgent.ts` (sub-agent loop). `swarm.ts`
+        // historically had a third one but is now a shim (kept exempt as
+        // a re-export point in case the shim ever needs to compose).
+        // Anything else hosting both `chat(` and `executeTools(` in the
+        // same file with a `for/while` loop nearby is suspect.
+        const ALLOWED = new Set([
+            'src/agent/agentLoop.ts',
+            'src/agent/subAgent.ts',
+            'src/agent/agent.ts',          // top-level coordinator
+            'src/agent/agentWakeup.ts',    // scheduled-wake driver
+            'src/agent/multiAgent.ts',     // channel router
+            'src/agent/parallelTools.ts',  // tool-level parallelism, not agent loop
+            'src/agent/swarm.ts',          // shim — kept allowlisted in case future composition lands
+            'src/agent/orchestrator.ts',   // delegation analyzer; legitimately calls executeTools sometimes
+            'src/agent/peerAdvise.ts',     // peer-advise pattern
+            'src/agent/verifier.ts',       // self-verification loop
+        ]);
+        const offenders: string[] = [];
+        for (const file of AGENT_FILES) {
+            const rel = file.replace(REPO_ROOT + '/', '');
+            if (ALLOWED.has(rel)) continue;
+            const src = readFileSync(file, 'utf8');
+            // Must call both primitives AND have a loop construct in the
+            // same file. Either alone is fine (helper modules, parsers,
+            // etc.).
+            const callsChat = /\bchat\s*\(/.test(src);
+            const callsExecuteTools = /\bexecuteTools\s*\(/.test(src);
+            const hasLoop = /\b(?:for|while)\s*\(/.test(src);
+            if (callsChat && callsExecuteTools && hasLoop) {
+                offenders.push(rel);
+            }
+        }
+        expect(offenders, `Files appearing to host their own chat+executeTools+loop (likely a parallel agent loop): ${offenders.join(', ')}`).toEqual([]);
+    });
+});
+
+describe('architecture contract — sub-agent canonical entry', () => {
+    it('exactly one definition of `export async function spawnSubAgent` exists', () => {
+        // Sanity check that the canonical primitive isn't accidentally
+        // shadowed by a duplicate export.
+        let hits = 0;
+        for (const file of AGENT_FILES) {
+            const src = readFileSync(file, 'utf8');
+            const matches = src.match(/export\s+async\s+function\s+spawnSubAgent\b/g);
+            if (matches) hits += matches.length;
+        }
+        expect(hits).toBe(1);
+    });
+});

--- a/tests/swarm.test.ts
+++ b/tests/swarm.test.ts
@@ -1,7 +1,18 @@
 /**
  * TITAN — Swarm Architecture Tests
- * Tests for src/agent/swarm.ts: getSwarmRouterTools, runSubAgent, domain mapping,
- * multi-round execution, error handling, concurrent agents, and edge cases.
+ *
+ * v5.4.x rewrite: `runSubAgent` no longer hosts its own mini-loop. It is a
+ * thin shim over `spawnSubAgent` (the canonical sub-agent path). These tests
+ * verify the shim contract — domain → tool allowlist mapping, model
+ * passthrough, output formatting, error handling — by mocking
+ * `spawnSubAgent` directly. Internal loop semantics (rounds, stall/loop
+ * detection, message history) are owned by `spawnSubAgent` and exercised in
+ * `tests/subAgent.test.ts`.
+ *
+ * The historical tests that asserted on `chat()` mock call args were
+ * dropped: they were testing the wrong layer (an internal mini-loop that
+ * no longer exists). What matters now is that swarm hands the right
+ * inputs to the canonical primitive.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -9,12 +20,16 @@ vi.mock('../src/utils/logger.js', () => ({
     default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('../src/providers/router.js', () => ({
-    chat: vi.fn().mockResolvedValue({ content: 'Sub-agent result', toolCalls: undefined }),
+vi.mock('../src/agent/subAgent.js', () => ({
+    spawnSubAgent: vi.fn().mockResolvedValue({
+        content: 'Sub-agent result',
+        toolsUsed: [],
+        rounds: 1,
+        success: true,
+    }),
 }));
 
 vi.mock('../src/agent/toolRunner.js', () => ({
-    executeTools: vi.fn().mockResolvedValue([]),
     getToolDefinitions: vi.fn().mockReturnValue([
         { type: 'function', function: { name: 'read_file', description: 'Read a file', parameters: {} } },
         { type: 'function', function: { name: 'write_file', description: 'Write a file', parameters: {} } },
@@ -25,16 +40,19 @@ vi.mock('../src/agent/toolRunner.js', () => ({
 }));
 
 import { getSwarmRouterTools, runSubAgent, type Domain } from '../src/agent/swarm.js';
-import { chat } from '../src/providers/router.js';
-import { executeTools, getToolDefinitions } from '../src/agent/toolRunner.js';
+import { spawnSubAgent } from '../src/agent/subAgent.js';
+import { getToolDefinitions } from '../src/agent/toolRunner.js';
 import logger from '../src/utils/logger.js';
 
 describe('Swarm', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Reset default mock behaviors
-        vi.mocked(chat).mockResolvedValue({ content: 'Sub-agent result', toolCalls: undefined });
-        vi.mocked(executeTools).mockResolvedValue([]);
+        vi.mocked(spawnSubAgent).mockResolvedValue({
+            content: 'Sub-agent result',
+            toolsUsed: [],
+            rounds: 1,
+            success: true,
+        });
         vi.mocked(getToolDefinitions).mockReturnValue([
             { type: 'function', function: { name: 'read_file', description: 'Read a file', parameters: {} } },
             { type: 'function', function: { name: 'write_file', description: 'Write a file', parameters: {} } },
@@ -47,321 +65,120 @@ describe('Swarm', () => {
     // ─── getSwarmRouterTools ────────────────────────────────────────
     describe('getSwarmRouterTools', () => {
         it('returns exactly 4 tools', () => {
-            const tools = getSwarmRouterTools();
-            expect(tools.length).toBe(4);
+            expect(getSwarmRouterTools().length).toBe(4);
         });
 
-        it('includes file agent tool', () => {
+        it.each([
+            ['delegate_to_file_agent'],
+            ['delegate_to_web_agent'],
+            ['delegate_to_system_agent'],
+            ['delegate_to_memory_agent'],
+        ])('includes %s', (name) => {
             const tools = getSwarmRouterTools();
-            const fileTool = tools.find(t => t.function.name === 'delegate_to_file_agent');
-            expect(fileTool).toBeDefined();
+            expect(tools.find(t => t.function.name === name)).toBeDefined();
         });
 
-        it('includes web agent tool', () => {
-            const tools = getSwarmRouterTools();
-            const webTool = tools.find(t => t.function.name === 'delegate_to_web_agent');
-            expect(webTool).toBeDefined();
-        });
-
-        it('includes system agent tool', () => {
-            const tools = getSwarmRouterTools();
-            const sysTool = tools.find(t => t.function.name === 'delegate_to_system_agent');
-            expect(sysTool).toBeDefined();
-        });
-
-        it('includes memory agent tool', () => {
-            const tools = getSwarmRouterTools();
-            const memTool = tools.find(t => t.function.name === 'delegate_to_memory_agent');
-            expect(memTool).toBeDefined();
-        });
-
-        it('each tool has correct type "function"', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                expect(tool.type).toBe('function');
-            }
-        });
-
-        it('each tool has an instruction parameter', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                expect(tool.function.parameters).toHaveProperty('properties');
-                expect((tool.function.parameters as any).properties).toHaveProperty('instruction');
-            }
-        });
-
-        it('instruction is a required parameter', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                expect((tool.function.parameters as any).required).toContain('instruction');
-            }
-        });
-
-        it('each tool has a description', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                expect(typeof tool.function.description).toBe('string');
-                expect(tool.function.description.length).toBeGreaterThan(0);
-            }
-        });
-
-        it('each tool has a unique name', () => {
-            const tools = getSwarmRouterTools();
-            const names = tools.map(t => t.function.name);
-            expect(new Set(names).size).toBe(4);
-        });
-
-        it('returns consistent results on multiple calls', () => {
-            const tools1 = getSwarmRouterTools();
-            const tools2 = getSwarmRouterTools();
-            expect(tools1.length).toBe(tools2.length);
-            for (let i = 0; i < tools1.length; i++) {
-                expect(tools1[i].function.name).toBe(tools2[i].function.name);
-            }
-        });
-
-        it('file agent description mentions file system operations', () => {
-            const tools = getSwarmRouterTools();
-            const fileTool = tools.find(t => t.function.name === 'delegate_to_file_agent')!;
-            const desc = fileTool.function.description.toLowerCase();
-            expect(desc).toMatch(/file|read|writ|director/);
-        });
-
-        it('web agent description mentions web operations', () => {
-            const tools = getSwarmRouterTools();
-            const webTool = tools.find(t => t.function.name === 'delegate_to_web_agent')!;
-            const desc = webTool.function.description.toLowerCase();
-            expect(desc).toMatch(/web|search|url|browser/);
-        });
-
-        it('system agent description mentions shell or process operations', () => {
-            const tools = getSwarmRouterTools();
-            const sysTool = tools.find(t => t.function.name === 'delegate_to_system_agent')!;
-            const desc = sysTool.function.description.toLowerCase();
-            expect(desc).toMatch(/shell|command|process|os/);
-        });
-
-        it('memory agent description mentions memory or knowledge', () => {
-            const tools = getSwarmRouterTools();
-            const memTool = tools.find(t => t.function.name === 'delegate_to_memory_agent')!;
-            const desc = memTool.function.description.toLowerCase();
-            expect(desc).toMatch(/memory|fact|knowledge|sav/);
-        });
-
-        it('instruction parameter has type string', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                const instrDef = (tool.function.parameters as any).properties.instruction;
-                expect(instrDef.type).toBe('string');
-            }
-        });
-
-        it('instruction parameter has a description', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                const instrDef = (tool.function.parameters as any).properties.instruction;
-                expect(typeof instrDef.description).toBe('string');
-                expect(instrDef.description.length).toBeGreaterThan(0);
-            }
-        });
-
-        it('all tool names follow delegate_to_*_agent pattern', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                expect(tool.function.name).toMatch(/^delegate_to_\w+_agent$/);
-            }
-        });
-
-        it('parameters use type "object"', () => {
-            const tools = getSwarmRouterTools();
-            for (const tool of tools) {
-                expect((tool.function.parameters as any).type).toBe('object');
+        it('every tool has an instruction parameter', () => {
+            for (const tool of getSwarmRouterTools()) {
+                const params = tool.function.parameters as { properties: Record<string, unknown>; required: string[]; type: string };
+                expect(params.type).toBe('object');
+                expect(params.properties.instruction).toBeDefined();
+                expect(params.required).toContain('instruction');
             }
         });
     });
 
-    // ─── runSubAgent ────────────────────────────────────────────────
+    // ─── runSubAgent — shim contract ────────────────────────────────
     describe('runSubAgent', () => {
-        it('returns result for file domain', async () => {
+        it('formats the result with the domain prefix', async () => {
             const result = await runSubAgent('file', 'Read /tmp/test.txt', 'openai/gpt-4o');
-            expect(result).toContain('Sub-Agent Result');
-            expect(result).toContain('file');
-            expect(result).toContain('Sub-agent result');
+            expect(result).toBe('[Sub-Agent Result / Domain: file]\nSub-agent result');
         });
 
-        it('returns result for web domain', async () => {
-            const result = await runSubAgent('web', 'Search for TypeScript docs', 'openai/gpt-4o');
-            expect(result).toContain('web');
-            expect(result).toContain('Sub-agent result');
-        });
+        it.each([['file'], ['web'], ['system'], ['memory']] as Array<[Domain]>)(
+            'tags result with %s domain',
+            async (domain) => {
+                const result = await runSubAgent(domain, 'task', 'openai/gpt-4o');
+                expect(result).toContain(`Domain: ${domain}`);
+            },
+        );
 
-        it('returns result for system domain', async () => {
-            const result = await runSubAgent('system', 'Run ls -la', 'openai/gpt-4o');
-            expect(result).toContain('system');
-        });
-
-        it('returns result for memory domain', async () => {
-            const result = await runSubAgent('memory', 'Remember this fact', 'openai/gpt-4o');
-            expect(result).toContain('memory');
-        });
-
-        it('calls chat with correct model', async () => {
-            await runSubAgent('file', 'Test instruction', 'anthropic/claude-sonnet-4-20250514');
-            expect(vi.mocked(chat)).toHaveBeenCalledWith(
+        it('passes the model through to spawnSubAgent', async () => {
+            await runSubAgent('file', 'task', 'anthropic/claude-sonnet-4-20250514');
+            expect(spawnSubAgent).toHaveBeenCalledWith(
                 expect.objectContaining({ model: 'anthropic/claude-sonnet-4-20250514' }),
             );
         });
 
-        it('calls chat with system message containing domain', async () => {
-            await runSubAgent('web', 'Search for X', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            const systemMsg = callArgs.messages.find((m: any) => m.role === 'system');
-            expect(systemMsg).toBeDefined();
-            expect(systemMsg!.content).toContain('WEB');
+        it('passes the instruction as the task', async () => {
+            await runSubAgent('file', 'Read /etc/hosts file', 'openai/gpt-4o');
+            expect(spawnSubAgent).toHaveBeenCalledWith(
+                expect.objectContaining({ task: 'Read /etc/hosts file' }),
+            );
         });
 
-        it('calls chat with user message containing instruction', async () => {
-            await runSubAgent('file', 'Read the config file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            const userMsg = callArgs.messages.find((m: any) => m.role === 'user');
-            expect(userMsg).toBeDefined();
-            expect(userMsg!.content).toBe('Read the config file');
+        it('caps maxRounds at 3 (matches historical mini-loop budget)', async () => {
+            await runSubAgent('web', 'Search', 'openai/gpt-4o');
+            expect(spawnSubAgent).toHaveBeenCalledWith(
+                expect.objectContaining({ maxRounds: 3 }),
+            );
         });
 
-        it('handles tool calls in response (executes and continues loop)', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'Running tool...',
-                    toolCalls: [{ id: 'tc-1', type: 'function', function: { name: 'read_file', arguments: '{"path":"/tmp/x"}' } }],
-                })
-                .mockResolvedValueOnce({
-                    content: 'File read successfully',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-1', name: 'read_file', content: 'file data', success: true, durationMs: 10 },
-            ]);
-
-            const result = await runSubAgent('file', 'Read a file', 'openai/gpt-4o');
-            expect(result).toContain('File read successfully');
-            expect(vi.mocked(chat)).toHaveBeenCalledTimes(2);
-            expect(vi.mocked(executeTools)).toHaveBeenCalledTimes(1);
+        it('names the spawned agent swarm-<domain> for governance feeds', async () => {
+            await runSubAgent('system', 'task', 'openai/gpt-4o');
+            expect(spawnSubAgent).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'swarm-system' }),
+            );
         });
 
-        it('handles errors gracefully', async () => {
-            vi.mocked(chat).mockRejectedValueOnce(new Error('API timeout'));
-            const result = await runSubAgent('web', 'Search X', 'openai/gpt-4o');
-            expect(result).toContain('error');
-            expect(result).toContain('API timeout');
+        it('restricts tools to file domain when domain=file', async () => {
+            await runSubAgent('file', 'task', 'openai/gpt-4o');
+            const args = vi.mocked(spawnSubAgent).mock.calls[0][0];
+            expect(args.tools).toEqual(expect.arrayContaining(['read_file', 'write_file']));
+            expect(args.tools).not.toContain('web_search');
+            expect(args.tools).not.toContain('shell');
         });
 
-        it('respects 3-round maximum', async () => {
-            // Each round returns tool calls, forcing continuation
-            vi.mocked(chat).mockResolvedValue({
-                content: 'still working...',
-                toolCalls: [{ id: 'tc', type: 'function', function: { name: 'shell', arguments: '{}' } }],
+        it('restricts tools to web domain when domain=web', async () => {
+            await runSubAgent('web', 'task', 'openai/gpt-4o');
+            const args = vi.mocked(spawnSubAgent).mock.calls[0][0];
+            expect(args.tools).toContain('web_search');
+            expect(args.tools).not.toContain('read_file');
+        });
+
+        it('restricts tools to system domain when domain=system', async () => {
+            await runSubAgent('system', 'task', 'openai/gpt-4o');
+            const args = vi.mocked(spawnSubAgent).mock.calls[0][0];
+            expect(args.tools).toContain('shell');
+            expect(args.tools).not.toContain('web_search');
+        });
+
+        it('restricts tools to memory domain when domain=memory', async () => {
+            await runSubAgent('memory', 'task', 'openai/gpt-4o');
+            const args = vi.mocked(spawnSubAgent).mock.calls[0][0];
+            expect(args.tools).toContain('memory_skill');
+        });
+
+        it('returns silently-completed message when spawnSubAgent yields empty content', async () => {
+            vi.mocked(spawnSubAgent).mockResolvedValueOnce({
+                content: '', toolsUsed: [], rounds: 1, success: true,
             });
-            vi.mocked(executeTools).mockResolvedValue([
-                { toolCallId: 'tc', name: 'shell', content: 'ok', success: true, durationMs: 5 },
-            ]);
-
-            const result = await runSubAgent('system', 'Do stuff', 'openai/gpt-4o');
-            // Should stop after 3 rounds
-            expect(vi.mocked(chat)).toHaveBeenCalledTimes(3);
-            expect(result).toContain('Max sub-agent rounds');
-        });
-
-        it('handles empty content response', async () => {
-            vi.mocked(chat).mockResolvedValueOnce({
-                content: '',
-                toolCalls: undefined,
-            });
-            const result = await runSubAgent('file', 'Do something', 'openai/gpt-4o');
+            const result = await runSubAgent('file', 'task', 'openai/gpt-4o');
             expect(result).toContain('Task completed silently');
         });
 
-        it('passes domain-specific tools to chat', async () => {
-            await runSubAgent('file', 'Read files', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            // Tools should be filtered for the file domain
-            if (callArgs.tools) {
-                for (const tool of callArgs.tools) {
-                    // file domain tools: read_file, write_file
-                    expect(['read_file', 'write_file', 'edit_file', 'list_dir', 'filesystem']).toContain(tool.function.name);
-                }
-            }
+        it('catches errors thrown by spawnSubAgent and returns a string', async () => {
+            vi.mocked(spawnSubAgent).mockRejectedValueOnce(new Error('Connection refused'));
+            const result = await runSubAgent('web', 'task', 'openai/gpt-4o');
+            expect(result).toContain('error');
+            expect(result).toContain('Connection refused');
+            expect(logger.error).toHaveBeenCalledWith(
+                'Swarm',
+                expect.stringContaining('Connection refused'),
+            );
         });
 
-        it('uses low temperature (0.2)', async () => {
-            await runSubAgent('file', 'Read file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            expect(callArgs.temperature).toBe(0.2);
-        });
-
-        it('uses maxTokens of 4096', async () => {
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            expect(callArgs.maxTokens).toBe(4096);
-        });
-
-        it('includes domain name in result', async () => {
-            const result = await runSubAgent('memory', 'Save fact', 'openai/gpt-4o');
-            expect(result).toContain('Domain: memory');
-        });
-
-        it('handles multiple tool calls in single response', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'Executing multiple tools',
-                    toolCalls: [
-                        { id: 'tc-1', type: 'function', function: { name: 'read_file', arguments: '{"path":"/a"}' } },
-                        { id: 'tc-2', type: 'function', function: { name: 'write_file', arguments: '{"path":"/b"}' } },
-                    ],
-                })
-                .mockResolvedValueOnce({
-                    content: 'All done',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-1', name: 'read_file', content: 'data1', success: true, durationMs: 5 },
-                { toolCallId: 'tc-2', name: 'write_file', content: 'ok', success: true, durationMs: 5 },
-            ]);
-
-            const result = await runSubAgent('file', 'Read and write', 'openai/gpt-4o');
-            expect(result).toContain('All done');
-        });
-
-        it('tool results are added to messages as tool role', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: '',
-                    toolCalls: [{ id: 'tc-x', type: 'function', function: { name: 'shell', arguments: '{}' } }],
-                })
-                .mockResolvedValueOnce({
-                    content: 'Final answer',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-x', name: 'shell', content: 'shell output', success: true, durationMs: 3 },
-            ]);
-
-            await runSubAgent('system', 'Run command', 'openai/gpt-4o');
-            // Second chat call should have tool message in its messages
-            const secondCallMessages = vi.mocked(chat).mock.calls[1][0].messages;
-            const toolMsg = secondCallMessages.find((m: any) => m.role === 'tool');
-            expect(toolMsg).toBeDefined();
-            expect(toolMsg!.content).toBe('shell output');
-        });
-
-        it('passes undefined tools when domain has no matching tools', async () => {
-            // Override getToolDefinitions to return empty
-            vi.mocked(getToolDefinitions).mockReturnValueOnce([]);
-            await runSubAgent('memory', 'Save fact', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            expect(callArgs.tools).toBeUndefined();
-        });
-
-        it('logs info when spawning a sub-agent', async () => {
+        it('logs an info line when spawning', async () => {
             await runSubAgent('file', 'Read something', 'openai/gpt-4o');
             expect(logger.info).toHaveBeenCalledWith(
                 'Swarm',
@@ -369,480 +186,46 @@ describe('Swarm', () => {
             );
         });
 
-        it('logs debug for each round', async () => {
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            expect(logger.debug).toHaveBeenCalledWith(
-                'Swarm',
-                expect.stringContaining('Round 1'),
-            );
-        });
-
-        it('logs error when chat throws', async () => {
-            vi.mocked(chat).mockRejectedValueOnce(new Error('Connection refused'));
-            await runSubAgent('system', 'Run cmd', 'openai/gpt-4o');
-            expect(logger.error).toHaveBeenCalledWith(
-                'Swarm',
-                expect.stringContaining('Connection refused'),
-            );
-        });
-
-        it('system message includes the instruction text', async () => {
-            await runSubAgent('file', 'Read /etc/hosts file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            const systemMsg = callArgs.messages.find((m: any) => m.role === 'system');
-            expect(systemMsg!.content).toContain('Read /etc/hosts file');
-        });
-
-        it('system message identifies the correct domain sub-agent', async () => {
-            for (const domain of ['file', 'web', 'system', 'memory'] as Domain[]) {
-                vi.clearAllMocks();
-                vi.mocked(chat).mockResolvedValue({ content: 'ok', toolCalls: undefined });
-                await runSubAgent(domain, 'test', 'openai/gpt-4o');
-                const callArgs = vi.mocked(chat).mock.calls[0][0];
-                const systemMsg = callArgs.messages.find((m: any) => m.role === 'system');
-                expect(systemMsg!.content).toContain(domain.toUpperCase());
-            }
-        });
-
-        it('assistant message with tool calls is added to conversation', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'Calling tool',
-                    toolCalls: [{ id: 'tc-1', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
-                })
-                .mockResolvedValueOnce({
-                    content: 'Done',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-1', name: 'read_file', content: 'data', success: true, durationMs: 5 },
-            ]);
-
-            await runSubAgent('file', 'Read file', 'openai/gpt-4o');
-
-            const secondCallMessages = vi.mocked(chat).mock.calls[1][0].messages;
-            const assistantMsg = secondCallMessages.find((m: any) => m.role === 'assistant' && m.toolCalls);
-            expect(assistantMsg).toBeDefined();
-            expect(assistantMsg!.toolCalls).toHaveLength(1);
-            expect(assistantMsg!.toolCalls![0].id).toBe('tc-1');
-        });
-
-        it('handles null content from chat gracefully', async () => {
-            vi.mocked(chat).mockResolvedValueOnce({
-                content: null as any,
-                toolCalls: undefined,
-            });
-            const result = await runSubAgent('file', 'Do something', 'openai/gpt-4o');
-            expect(result).toContain('Task completed silently');
-        });
-
-        it('handles executeTools returning failed results', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'Trying',
-                    toolCalls: [{ id: 'tc-fail', type: 'function', function: { name: 'shell', arguments: '{}' } }],
-                })
-                .mockResolvedValueOnce({
-                    content: 'Handled failure',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-fail', name: 'shell', content: 'Error: permission denied', success: false, durationMs: 5 },
-            ]);
-
-            const result = await runSubAgent('system', 'Run cmd', 'openai/gpt-4o');
-            expect(result).toContain('Handled failure');
-        });
-
-        it('preserves tool call ID in messages for proper correlation', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: '',
-                    toolCalls: [{ id: 'unique-id-123', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
-                })
-                .mockResolvedValueOnce({
-                    content: 'Final',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'unique-id-123', name: 'read_file', content: 'data', success: true, durationMs: 5 },
-            ]);
-
-            await runSubAgent('file', 'Read', 'openai/gpt-4o');
-
-            const secondCallMessages = vi.mocked(chat).mock.calls[1][0].messages;
-            const toolMsg = secondCallMessages.find((m: any) => m.role === 'tool');
-            expect(toolMsg!.toolCallId).toBe('unique-id-123');
-        });
-
-        it('error in round 2 after successful round 1 returns error result', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'Round 1',
-                    toolCalls: [{ id: 'tc-1', type: 'function', function: { name: 'shell', arguments: '{}' } }],
-                })
-                .mockRejectedValueOnce(new Error('Round 2 failure'));
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-1', name: 'shell', content: 'ok', success: true, durationMs: 5 },
-            ]);
-
-            const result = await runSubAgent('system', 'Multi step', 'openai/gpt-4o');
-            expect(result).toContain('error');
-            expect(result).toContain('Round 2 failure');
-        });
-
-        it('result format starts with [Sub-Agent Result', async () => {
-            const result = await runSubAgent('file', 'Test', 'openai/gpt-4o');
-            expect(result).toMatch(/^\[Sub-Agent Result/);
-        });
-
-        it('each tool result is added as separate message', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'Multi tools',
-                    toolCalls: [
-                        { id: 'tc-a', type: 'function', function: { name: 'read_file', arguments: '{}' } },
-                        { id: 'tc-b', type: 'function', function: { name: 'write_file', arguments: '{}' } },
-                    ],
-                })
-                .mockResolvedValueOnce({
-                    content: 'Done',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc-a', name: 'read_file', content: 'data-a', success: true, durationMs: 5 },
-                { toolCallId: 'tc-b', name: 'write_file', content: 'data-b', success: true, durationMs: 5 },
-            ]);
-
-            await runSubAgent('file', 'Multi', 'openai/gpt-4o');
-
-            const secondCallMessages = vi.mocked(chat).mock.calls[1][0].messages;
-            const toolMsgs = secondCallMessages.filter((m: any) => m.role === 'tool');
-            expect(toolMsgs).toHaveLength(2);
-            expect(toolMsgs[0].content).toBe('data-a');
-            expect(toolMsgs[1].content).toBe('data-b');
-        });
-
-        it('exactly 3 rounds of tool calls returns max rounds message', async () => {
-            vi.mocked(chat).mockResolvedValue({
-                content: 'working',
-                toolCalls: [{ id: 'tc', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
-            });
-            vi.mocked(executeTools).mockResolvedValue([
-                { toolCallId: 'tc', name: 'read_file', content: 'ok', success: true, durationMs: 5 },
-            ]);
-
-            const result = await runSubAgent('file', 'Lots of work', 'openai/gpt-4o');
-            expect(vi.mocked(chat)).toHaveBeenCalledTimes(3);
-            expect(result).toContain('Max sub-agent rounds reached');
-            expect(result).toContain('Partial results');
-        });
-
-        it('completes in 2 rounds if tool calls stop on round 2', async () => {
-            vi.mocked(chat)
-                .mockResolvedValueOnce({
-                    content: 'round 1',
-                    toolCalls: [{ id: 'tc1', type: 'function', function: { name: 'shell', arguments: '{}' } }],
-                })
-                .mockResolvedValueOnce({
-                    content: 'Final result after 2 rounds',
-                    toolCalls: undefined,
-                });
-            vi.mocked(executeTools).mockResolvedValueOnce([
-                { toolCallId: 'tc1', name: 'shell', content: 'ok', success: true, durationMs: 5 },
-            ]);
-
-            const result = await runSubAgent('system', 'Two step task', 'openai/gpt-4o');
-            expect(vi.mocked(chat)).toHaveBeenCalledTimes(2);
-            expect(result).toContain('Final result after 2 rounds');
-            expect(result).not.toContain('Max sub-agent rounds');
-        });
-    });
-
-    // ─── Concurrent sub-agents ─────────────────────────────────────
-    describe('concurrent sub-agents', () => {
-        it('multiple sub-agents can run in parallel', async () => {
-            vi.mocked(chat).mockResolvedValue({ content: 'Result from agent', toolCalls: undefined });
-
+        it('multiple sub-agents can run in parallel without crossing wires', async () => {
             const results = await Promise.all([
-                runSubAgent('file', 'Read /a', 'openai/gpt-4o'),
-                runSubAgent('web', 'Search B', 'openai/gpt-4o'),
-                runSubAgent('system', 'Run cmd', 'openai/gpt-4o'),
-                runSubAgent('memory', 'Save fact', 'openai/gpt-4o'),
+                runSubAgent('file', 'task A', 'openai/gpt-4o'),
+                runSubAgent('web', 'task B', 'openai/gpt-4o'),
+                runSubAgent('system', 'task C', 'openai/gpt-4o'),
+                runSubAgent('memory', 'task D', 'openai/gpt-4o'),
             ]);
-
-            expect(results).toHaveLength(4);
             expect(results[0]).toContain('Domain: file');
             expect(results[1]).toContain('Domain: web');
             expect(results[2]).toContain('Domain: system');
             expect(results[3]).toContain('Domain: memory');
-            expect(vi.mocked(chat)).toHaveBeenCalledTimes(4);
+            expect(spawnSubAgent).toHaveBeenCalledTimes(4);
         });
 
-        it('one failing sub-agent does not block others', async () => {
-            let callCount = 0;
-            vi.mocked(chat).mockImplementation(async () => {
-                callCount++;
-                if (callCount === 2) throw new Error('One agent failed');
-                return { content: 'Success', toolCalls: undefined };
+        it('one failing spawn does not block sibling spawns', async () => {
+            let n = 0;
+            vi.mocked(spawnSubAgent).mockImplementation(async () => {
+                n++;
+                if (n === 2) throw new Error('one agent failed');
+                return { content: 'Success', toolsUsed: [], rounds: 1, success: true };
             });
 
             const results = await Promise.all([
-                runSubAgent('file', 'Read', 'openai/gpt-4o'),
-                runSubAgent('web', 'Search', 'openai/gpt-4o'),
-                runSubAgent('system', 'Run', 'openai/gpt-4o'),
+                runSubAgent('file', 'A', 'openai/gpt-4o'),
+                runSubAgent('web', 'B', 'openai/gpt-4o'),
+                runSubAgent('system', 'C', 'openai/gpt-4o'),
             ]);
-
-            // All should resolve (no unhandled rejections)
-            expect(results).toHaveLength(3);
             expect(results[0]).toContain('Success');
             expect(results[1]).toContain('error');
             expect(results[2]).toContain('Success');
-        });
-
-        it('concurrent agents use independent message histories', async () => {
-            let fileCallCount = 0;
-            let webCallCount = 0;
-
-            vi.mocked(chat).mockImplementation(async (args: any) => {
-                const systemMsg = args.messages.find((m: any) => m.role === 'system');
-                if (systemMsg?.content?.includes('FILE')) {
-                    fileCallCount++;
-                    if (fileCallCount === 1) {
-                        return {
-                            content: 'File tool',
-                            toolCalls: [{ id: 'tc-file', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
-                        };
-                    }
-                    return { content: 'File done', toolCalls: undefined };
-                }
-                webCallCount++;
-                return { content: 'Web done immediately', toolCalls: undefined };
-            });
-
-            vi.mocked(executeTools).mockResolvedValue([
-                { toolCallId: 'tc-file', name: 'read_file', content: 'data', success: true, durationMs: 5 },
-            ]);
-
-            const [fileResult, webResult] = await Promise.all([
-                runSubAgent('file', 'Read file', 'openai/gpt-4o'),
-                runSubAgent('web', 'Search web', 'openai/gpt-4o'),
-            ]);
-
-            expect(fileResult).toContain('File done');
-            expect(webResult).toContain('Web done immediately');
-        });
-    });
-
-    // ─── Domain mapping ─────────────────────────────────────────────
-    describe('Domain mapping', () => {
-        it('read_file is mapped to file domain', async () => {
-            await runSubAgent('file', 'Read file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).toContain('read_file');
-            }
-        });
-
-        it('write_file is mapped to file domain', async () => {
-            await runSubAgent('file', 'Write file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).toContain('write_file');
-            }
-        });
-
-        it('web_search is mapped to web domain', async () => {
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).toContain('web_search');
-            }
-        });
-
-        it('shell is mapped to system domain', async () => {
-            await runSubAgent('system', 'Run cmd', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).toContain('shell');
-            }
-        });
-
-        it('memory_skill is mapped to memory domain', async () => {
-            await runSubAgent('memory', 'Remember X', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).toContain('memory_skill');
-            }
-        });
-
-        it('file domain does not include web_search', async () => {
-            await runSubAgent('file', 'Read', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('web_search');
-            }
-        });
-
-        it('web domain does not include shell', async () => {
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('shell');
-            }
-        });
-
-        it('system domain does not include read_file', async () => {
-            await runSubAgent('system', 'Run', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('read_file');
-            }
-        });
-
-        it('memory domain does not include write_file', async () => {
-            await runSubAgent('memory', 'Save', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('write_file');
-            }
-        });
-
-        it('unrecognized tools default to file domain', async () => {
-            // Add an unrecognized tool
-            vi.mocked(getToolDefinitions).mockReturnValueOnce([
-                { type: 'function', function: { name: 'unknown_tool', description: 'Unknown', parameters: {} } },
-                { type: 'function', function: { name: 'read_file', description: 'Read', parameters: {} } },
-            ]);
-            await runSubAgent('file', 'Do stuff', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                // unknown_tool defaults to 'file' domain
-                expect(toolNames).toContain('unknown_tool');
-            }
-        });
-
-        it('file domain does not include shell', async () => {
-            await runSubAgent('file', 'Read file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('shell');
-            }
-        });
-
-        it('file domain does not include memory_skill', async () => {
-            await runSubAgent('file', 'Read file', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('memory_skill');
-            }
-        });
-
-        it('web domain does not include read_file', async () => {
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('read_file');
-            }
-        });
-
-        it('web domain does not include memory_skill', async () => {
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('memory_skill');
-            }
-        });
-
-        it('system domain does not include web_search', async () => {
-            await runSubAgent('system', 'Run', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('web_search');
-            }
-        });
-
-        it('system domain does not include memory_skill', async () => {
-            await runSubAgent('system', 'Run', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('memory_skill');
-            }
-        });
-
-        it('memory domain does not include shell', async () => {
-            await runSubAgent('memory', 'Save', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                expect(toolNames).not.toContain('shell');
-            }
-        });
-
-        it('unrecognized tools do NOT appear in web domain', async () => {
-            vi.mocked(getToolDefinitions).mockReturnValueOnce([
-                { type: 'function', function: { name: 'unknown_tool', description: 'Unknown', parameters: {} } },
-                { type: 'function', function: { name: 'web_search', description: 'Search', parameters: {} } },
-            ]);
-            await runSubAgent('web', 'Search', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            if (callArgs.tools && callArgs.tools.length > 0) {
-                const toolNames = callArgs.tools.map((t: any) => t.function.name);
-                // unknown_tool defaults to file domain, should NOT appear in web
-                expect(toolNames).not.toContain('unknown_tool');
-            }
-        });
-
-        it('all known file domain tools are included for file agent', async () => {
-            vi.mocked(getToolDefinitions).mockReturnValueOnce([
-                { type: 'function', function: { name: 'read_file', description: 'Read', parameters: {} } },
-                { type: 'function', function: { name: 'write_file', description: 'Write', parameters: {} } },
-                { type: 'function', function: { name: 'edit_file', description: 'Edit', parameters: {} } },
-                { type: 'function', function: { name: 'list_dir', description: 'List', parameters: {} } },
-                { type: 'function', function: { name: 'filesystem', description: 'FS', parameters: {} } },
-            ]);
-            await runSubAgent('file', 'Work with files', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            expect(callArgs.tools).toBeDefined();
-            expect(callArgs.tools!.length).toBe(5);
-        });
-
-        it('all known web domain tools are included for web agent', async () => {
-            vi.mocked(getToolDefinitions).mockReturnValueOnce([
-                { type: 'function', function: { name: 'web_search', description: 'Search', parameters: {} } },
-                { type: 'function', function: { name: 'web_fetch', description: 'Fetch', parameters: {} } },
-                { type: 'function', function: { name: 'webhook', description: 'Hook', parameters: {} } },
-                { type: 'function', function: { name: 'browser', description: 'Browser', parameters: {} } },
-            ]);
-            await runSubAgent('web', 'Web tasks', 'openai/gpt-4o');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            expect(callArgs.tools).toBeDefined();
-            expect(callArgs.tools!.length).toBe(4);
         });
     });
 
     // ─── Edge cases ────────────────────────────────────────────────
     describe('edge cases', () => {
         it('handles very long instruction string', async () => {
-            const longInstruction = 'A'.repeat(10000);
-            const result = await runSubAgent('file', longInstruction, 'openai/gpt-4o');
+            const long = 'A'.repeat(10000);
+            const result = await runSubAgent('file', long, 'openai/gpt-4o');
             expect(result).toContain('Domain: file');
+            expect(spawnSubAgent).toHaveBeenCalledWith(expect.objectContaining({ task: long }));
         });
 
         it('handles empty string instruction', async () => {
@@ -851,38 +234,33 @@ describe('Swarm', () => {
         });
 
         it('handles instruction with special characters', async () => {
-            const result = await runSubAgent('file', 'Read file with <html> & "quotes"', 'openai/gpt-4o');
+            const tricky = 'Read file with <html> & "quotes"';
+            const result = await runSubAgent('file', tricky, 'openai/gpt-4o');
             expect(result).toContain('Domain: file');
-            const callArgs = vi.mocked(chat).mock.calls[0][0];
-            const userMsg = callArgs.messages.find((m: any) => m.role === 'user');
-            expect(userMsg!.content).toContain('<html>');
+            expect(spawnSubAgent).toHaveBeenCalledWith(expect.objectContaining({ task: tricky }));
         });
 
-        it('handles chat returning empty toolCalls array', async () => {
-            vi.mocked(chat).mockResolvedValueOnce({
-                content: 'No tools needed',
-                toolCalls: [],
-            });
-            const result = await runSubAgent('file', 'Simple task', 'openai/gpt-4o');
-            expect(result).toContain('No tools needed');
-            expect(vi.mocked(executeTools)).not.toHaveBeenCalled();
+        it('hands an empty tool allowlist when the domain has no matching tools', async () => {
+            // If getToolDefinitions returns an empty list, the resolved domain
+            // tool array is empty. spawnSubAgent should still be called with
+            // tools=[] — the canonical primitive treats that as "no tools".
+            vi.mocked(getToolDefinitions).mockReturnValueOnce([]);
+            await runSubAgent('memory', 'task', 'openai/gpt-4o');
+            expect(spawnSubAgent).toHaveBeenCalledWith(
+                expect.objectContaining({ tools: [] }),
+            );
         });
 
-        it('handles different model strings correctly', async () => {
-            const models = [
-                'openai/gpt-4o',
-                'anthropic/claude-sonnet-4-20250514',
-                'google/gemini-pro',
-                'kimi-k2.5:cloud',
-            ];
-            for (const model of models) {
-                vi.clearAllMocks();
-                vi.mocked(chat).mockResolvedValue({ content: 'ok', toolCalls: undefined });
-                await runSubAgent('file', 'Test', model);
-                expect(vi.mocked(chat)).toHaveBeenCalledWith(
-                    expect.objectContaining({ model }),
-                );
-            }
+        it.each([
+            ['openai/gpt-4o'],
+            ['anthropic/claude-sonnet-4-20250514'],
+            ['google/gemini-pro'],
+            ['kimi-k2.5:cloud'],
+        ])('passes through model %s verbatim', async (model) => {
+            vi.clearAllMocks();
+            vi.mocked(spawnSubAgent).mockResolvedValue({ content: 'ok', toolsUsed: [], rounds: 1, success: true });
+            await runSubAgent('file', 'task', model);
+            expect(spawnSubAgent).toHaveBeenCalledWith(expect.objectContaining({ model }));
         });
     });
 });

--- a/tests/widget-gates.test.ts
+++ b/tests/widget-gates.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the widget management gates added in v5.4.x:
+ *
+ *   _____widget_remove   — delete one widget by id/source/name
+ *   _____widget_clear    — wipe every widget on the active canvas
+ *   _____widget_update   — modify name/dims/source on an existing widget
+ *
+ * Two layers under test:
+ *   1. ui/src/titan2/agent/protocol.ts — the gate extractor must surface the
+ *      new gates as ExecutionBlocks (not silently skip them like the
+ *      _____framework / _____transient gates).
+ *   2. src/gateway/server.ts — natural-language fast-paths for "clear the
+ *      canvas" and "remove the VRAM widget" must short-circuit to gate
+ *      emission without round-tripping through the LLM.
+ *
+ * The UI-side dispatcher is in ChatWidget.tsx (executeBlock). It runs in the
+ * browser and is not unit-tested here — exercised through e2e Playwright
+ * tests in a separate sweep.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractExecutionBlocks, validateExecutionContent } from '../ui/src/titan2/agent/protocol.js';
+
+describe('widget management gates — protocol parser', () => {
+    describe('extractExecutionBlocks', () => {
+        it('parses _____widget_remove with JSON body', () => {
+            const content = 'Removing the VRAM panel.\n\n_____widget_remove\n{ "source": "system:vram" }';
+            const blocks = extractExecutionBlocks(content);
+            expect(blocks).toHaveLength(1);
+            expect(blocks[0].gate).toBe('_____widget_remove');
+            expect(blocks[0].code).toBe('{ "source": "system:vram" }');
+            expect(blocks[0].leadingText).toBe('Removing the VRAM panel.');
+        });
+
+        it('parses _____widget_clear with empty JSON body', () => {
+            const content = 'Clearing the canvas.\n\n_____widget_clear\n{}';
+            const blocks = extractExecutionBlocks(content);
+            expect(blocks).toHaveLength(1);
+            expect(blocks[0].gate).toBe('_____widget_clear');
+            expect(blocks[0].code).toBe('{}');
+        });
+
+        it('parses _____widget_update with size patch', () => {
+            const content = 'Resizing.\n\n_____widget_update\n{ "source": "system:vram", "w": 8, "h": 8 }';
+            const blocks = extractExecutionBlocks(content);
+            expect(blocks).toHaveLength(1);
+            expect(blocks[0].gate).toBe('_____widget_update');
+            expect(blocks[0].code).toBe('{ "source": "system:vram", "w": 8, "h": 8 }');
+        });
+
+        it('handles a sequence of clear-then-add', () => {
+            const content = [
+                'Resetting the canvas first.',
+                '',
+                '_____widget_clear',
+                '{}',
+                '',
+                'Now adding fresh widgets.',
+                '',
+                '_____widget',
+                '{ "name": "Clock", "format": "system", "source": "system:clock", "w": 4, "h": 4 }',
+            ].join('\n');
+            const blocks = extractExecutionBlocks(content);
+            expect(blocks).toHaveLength(2);
+            expect(blocks[0].gate).toBe('_____widget_clear');
+            expect(blocks[1].gate).toBe('_____widget');
+        });
+
+        it('does not match a gate appearing inside a code body', () => {
+            // The agent might describe the gate inside docs/comments — those
+            // mid-line occurrences must not trigger a new block.
+            const content = '_____widget_remove\n// this comment mentions _____widget_clear inline\n{ "id": "w1" }';
+            const blocks = extractExecutionBlocks(content);
+            expect(blocks).toHaveLength(1);
+            expect(blocks[0].gate).toBe('_____widget_remove');
+            expect(blocks[0].code).toContain('_____widget_clear inline');
+        });
+    });
+
+    describe('validateExecutionContent', () => {
+        it('rejects two _____widget_remove blocks in one message', () => {
+            // Multiple blocks of the same gate per message are forbidden — see
+            // protocol.ts:138. Otherwise a botched response could destroy two
+            // widgets when the user asked for one.
+            const content = '_____widget_remove\n{ "id": "w1" }\n_____widget_remove\n{ "id": "w2" }';
+            const result = validateExecutionContent(content);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain('_____widget_remove');
+        });
+
+        it('accepts one of each new gate in a single message', () => {
+            const content = [
+                '_____widget_clear',
+                '{}',
+                '_____widget_remove',
+                '{ "id": "w1" }',
+                '_____widget_update',
+                '{ "id": "w2", "w": 6 }',
+            ].join('\n');
+            const result = validateExecutionContent(content);
+            expect(result.valid).toBe(true);
+        });
+    });
+});
+
+describe('widget management gates — server-side fast-paths', () => {
+    // These regexes mirror the live patterns in src/gateway/server.ts.
+    // Keeping them duplicated here is intentional — if someone tightens the
+    // server pattern without updating the test, CI tells us. The alternative
+    // (importing the regex from server.ts) drags the entire gateway module
+    // into a unit test for a 3-line pattern check.
+    const widgetClearPattern = /\b(?:clear|wipe|reset|empty)\s+(?:.*\b)?(?:canvas|widgets?|space|board|all)\b|\b(?:remove|delete)\s+(?:all|every|each)\b/i;
+    const widgetRemoveVerb = /\b(?:remove|delete|close|kill|hide)\b/i;
+
+    it('clear pattern matches typical phrasings', () => {
+        for (const phrase of [
+            'clear the canvas',
+            'wipe all widgets',
+            'reset my canvas please',
+            'empty the board',
+            'remove all widgets',
+            'delete every widget',
+        ]) {
+            expect(widgetClearPattern.test(phrase), phrase).toBe(true);
+        }
+    });
+
+    it('clear pattern does not fire on adjective uses or unrelated context', () => {
+        for (const phrase of [
+            'is the air clear today?',
+            'reset my password',
+            'add a clear-style widget',  // "clear-" — hyphen, not space
+            'start over from the recipe',
+        ]) {
+            expect(widgetClearPattern.test(phrase), phrase).toBe(false);
+        }
+    });
+
+    it('remove verb matches typical phrasings', () => {
+        for (const phrase of [
+            'remove the VRAM widget',
+            'delete the cron panel',
+            'close the backup widget',
+            'hide the training dashboard',
+        ]) {
+            expect(widgetRemoveVerb.test(phrase), phrase).toBe(true);
+        }
+    });
+});

--- a/ui/src/titan2/agent/protocol.ts
+++ b/ui/src/titan2/agent/protocol.ts
@@ -5,7 +5,17 @@
 
 import type { AgentGate, ExecutionBlock, AgentMessage, ExecutionResult } from '../types';
 
-const GATES: AgentGate[] = ['_____javascript', '_____react', '_____tool', '_____widget', '_____framework', '_____transient'];
+const GATES: AgentGate[] = [
+  '_____javascript',
+  '_____react',
+  '_____tool',
+  '_____widget',
+  '_____widget_remove',
+  '_____widget_clear',
+  '_____widget_update',
+  '_____framework',
+  '_____transient',
+];
 
 function findLineStart(content: string, index: number): number {
   let start = index;

--- a/ui/src/titan2/canvas/SpaceEngine.ts
+++ b/ui/src/titan2/canvas/SpaceEngine.ts
@@ -405,6 +405,39 @@ export const SpaceEngine = {
     this.save(space);
   },
 
+  /**
+   * Remove every widget in a space. Used by the `_____widget_clear` gate so
+   * the agent can wipe the canvas when the user asks for a fresh start.
+   * Returns the number of widgets removed.
+   */
+  clearWidgets(spaceId: string): number {
+    const space = this.get(spaceId);
+    if (!space) return 0;
+    const count = space.widgets.length;
+    if (USE_CRDT) {
+      clearYSpace(spaceId);
+    }
+    space.widgets = [];
+    this.save(space);
+    return count;
+  },
+
+  /**
+   * Find a widget by source id (e.g. `system:vram`) or display name.
+   * Used by `_____widget_remove` when the agent identifies a widget by
+   * human-readable handle rather than internal `id`. Returns the first
+   * match — names should be unique per space in practice.
+   */
+  findWidget(spaceId: string, identifier: { id?: string; source?: string; name?: string }): WidgetDef | undefined {
+    const space = this.get(spaceId);
+    if (!space) return undefined;
+    return space.widgets.find(w =>
+      (identifier.id && w.id === identifier.id) ||
+      (identifier.source && w.source === identifier.source) ||
+      (identifier.name && w.name === identifier.name),
+    );
+  },
+
   updateLayout(spaceId: string, layout: Array<{ i: string; x: number; y: number; w: number; h: number }>) {
     if (USE_CRDT) {
       for (const l of layout) {

--- a/ui/src/titan2/system/ChatWidget.tsx
+++ b/ui/src/titan2/system/ChatWidget.tsx
@@ -225,6 +225,30 @@ function Widget() {
   return <div>Hello from widget</div>;
 }
 
+### _____widget_remove
+For removing a single widget from the canvas. Body is JSON identifying the widget by \`id\`, \`source\`, or display \`name\` (first match wins).
+
+_____widget_remove
+{ "source": "system:vram" }
+
+_____widget_remove
+{ "name": "Clock" }
+
+### _____widget_clear
+For wiping every widget from the active canvas. Use only when the user explicitly asks to clear/reset/start over. Body may be empty JSON \`{}\` or a short note.
+
+_____widget_clear
+{}
+
+### _____widget_update
+For modifying an existing widget — change its name, dimensions (w/h), position (x/y), or replace its source. Identify the widget the same way as remove (\`id\`/\`source\`/\`name\`).
+
+_____widget_update
+{ "source": "system:vram", "w": 8, "h": 8 }
+
+_____widget_update
+{ "name": "Clock", "source": "function Widget(){ return <div>13:00</div>; }" }
+
 ### _____tool
 For calling backend tools or MCP servers.
 
@@ -689,6 +713,120 @@ export function ChatWidget({ space, onClose, onMascotState }: ChatWidgetProps) {
               error: { message: err.message || String(err), name: 'WidgetError', stack: '', text: String(err) },
             };
           }
+        }
+      }
+
+      if (gate === '_____widget_remove') {
+        // Remove a single widget by id, source, or display name. Body is JSON.
+        // Examples:
+        //   { "id": "widget_173_abc" }
+        //   { "source": "system:vram" }
+        //   { "name": "VRAM Monitor" }
+        const s = spaceRef.current;
+        try {
+          const parsed = JSON.parse(code);
+          const target = SpaceEngine.findWidget(s.id, parsed);
+          if (!target) {
+            const desc = parsed.id || parsed.source || parsed.name || 'unknown';
+            return {
+              status: 'error',
+              logs: [{ level: 'warn', text: `No widget found matching ${desc}` }],
+              resultText: '',
+              runId: Date.now(),
+              error: { message: `No widget matching ${desc}`, name: 'WidgetNotFound', stack: '', text: `No widget matching ${desc}` },
+            };
+          }
+          SpaceEngine.removeWidget(s.id, target.id);
+          window.dispatchEvent(new CustomEvent('titan:space:refresh', { detail: { spaceId: s.id } }));
+          return {
+            status: 'success',
+            logs: [{ level: 'info', text: `Removed widget ${target.name} (${target.id})` }],
+            resultText: `Removed ${target.name}`,
+            runId: Date.now(),
+          };
+        } catch (err: any) {
+          return {
+            status: 'error',
+            logs: [{ level: 'error', text: err.message || String(err) }],
+            resultText: '',
+            runId: Date.now(),
+            error: { message: err.message || String(err), name: 'WidgetError', stack: '', text: String(err) },
+          };
+        }
+      }
+
+      if (gate === '_____widget_clear') {
+        // Wipe all widgets from the active space. Body is ignored (may be empty
+        // or contain a confirmation note like "user requested fresh canvas").
+        const s = spaceRef.current;
+        try {
+          const removed = SpaceEngine.clearWidgets(s.id);
+          window.dispatchEvent(new CustomEvent('titan:space:refresh', { detail: { spaceId: s.id } }));
+          return {
+            status: 'success',
+            logs: [{ level: 'info', text: `Cleared ${removed} widget${removed === 1 ? '' : 's'} from canvas` }],
+            resultText: `Cleared ${removed} widget${removed === 1 ? '' : 's'}`,
+            runId: Date.now(),
+          };
+        } catch (err: any) {
+          return {
+            status: 'error',
+            logs: [{ level: 'error', text: err.message || String(err) }],
+            resultText: '',
+            runId: Date.now(),
+            error: { message: err.message || String(err), name: 'WidgetError', stack: '', text: String(err) },
+          };
+        }
+      }
+
+      if (gate === '_____widget_update') {
+        // Update a widget's props/size/source. Body is JSON.
+        // The agent must include `id` (or `source`/`name` to look up id) plus
+        // any of: name, w, h, source, format, x, y, props.
+        // Example: { "source": "system:vram", "w": 8, "h": 8 }
+        const s = spaceRef.current;
+        try {
+          const parsed = JSON.parse(code);
+          const target = SpaceEngine.findWidget(s.id, parsed);
+          if (!target) {
+            const desc = parsed.id || parsed.source || parsed.name || 'unknown';
+            return {
+              status: 'error',
+              logs: [{ level: 'warn', text: `No widget found matching ${desc}` }],
+              resultText: '',
+              runId: Date.now(),
+              error: { message: `No widget matching ${desc}`, name: 'WidgetNotFound', stack: '', text: `No widget matching ${desc}` },
+            };
+          }
+          // Build the patch — only include fields the agent actually provided.
+          // Don't blindly overwrite source with parsed.source unless it differs
+          // from the lookup key (otherwise updating by source would be a no-op
+          // patch that still triggers a refresh).
+          const patch: Partial<typeof target> = {};
+          if (typeof parsed.name === 'string') patch.name = parsed.name;
+          if (typeof parsed.format === 'string') patch.format = parsed.format;
+          if (typeof parsed.source === 'string' && parsed.source !== target.source && parsed.id) patch.source = parsed.source;
+          if (Number.isFinite(parsed.w)) patch.w = Math.max(1, Math.floor(parsed.w));
+          if (Number.isFinite(parsed.h)) patch.h = Math.max(1, Math.floor(parsed.h));
+          if (Number.isFinite(parsed.x)) patch.x = Math.max(0, Math.floor(parsed.x));
+          if (Number.isFinite(parsed.y)) patch.y = Math.max(0, Math.floor(parsed.y));
+          if (parsed.props && typeof parsed.props === 'object') (patch as any).props = parsed.props;
+          SpaceEngine.updateWidget(s.id, target.id, patch);
+          window.dispatchEvent(new CustomEvent('titan:space:refresh', { detail: { spaceId: s.id } }));
+          return {
+            status: 'success',
+            logs: [{ level: 'info', text: `Updated widget ${target.name} (${target.id})` }],
+            resultText: `Updated ${target.name}`,
+            runId: Date.now(),
+          };
+        } catch (err: any) {
+          return {
+            status: 'error',
+            logs: [{ level: 'error', text: err.message || String(err) }],
+            resultText: '',
+            runId: Date.now(),
+            error: { message: err.message || String(err), name: 'WidgetError', stack: '', text: String(err) },
+          };
         }
       }
 

--- a/ui/src/titan2/types.ts
+++ b/ui/src/titan2/types.ts
@@ -72,7 +72,16 @@ export interface SandboxAPI {
 
 // ── Agent Protocol Types ──────────────────────────────────────
 
-export type AgentGate = '_____javascript' | '_____react' | '_____tool' | '_____widget' | '_____framework' | '_____transient';
+export type AgentGate =
+  | '_____javascript'
+  | '_____react'
+  | '_____tool'
+  | '_____widget'
+  | '_____widget_remove'
+  | '_____widget_clear'
+  | '_____widget_update'
+  | '_____framework'
+  | '_____transient';
 
 export interface ExecutionBlock {
   gate: AgentGate;


### PR DESCRIPTION
Three connected wins, one PR.

WHAT
1. Three new gates for canvas widget lifecycle:
   - _____widget_remove   { id|source|name } → SpaceEngine.removeWidget
   - _____widget_clear    {}                 → SpaceEngine.clearWidgets
   - _____widget_update   { id|source|name, w?, h?, x?, y?, name?, source? }
                                             → SpaceEngine.updateWidget
   Wired into the protocol parser, the Titan-3 gate dispatcher in
   ChatWidget.tsx, and the gateway's natural-language fast-path (so
   'clear the canvas' or 'remove the VRAM widget' skip the LLM).
   System prompt updated so the agent emits them at the right moment.

2. Phase B — spawn-path consolidation. swarm.runSubAgent used to host
   its own chat+executeTools mini-loop, leaving spawned agents
   invisible to commandPost / budgetEnforcer / guardrails. It now
   delegates to the canonical spawnSubAgent. swarm.test.ts rewritten
   to mock the new contract — 79 tests collapsed to 32 focused on the
   shim's public surface (domain → tool allowlist, model passthrough,
   output formatting, error handling).

3. tests/architecture-contract.test.ts — encodes the AGENT-HIERARCHY.md
   contract:
   - Only swarm.ts may export runSubAgent (no parallel mini-loops).
   - 'You are the X sub-agent' prompts only in the canonical registry
     (specialists, specialistRouter, structuredSpawn, subAgent where
     SUB_AGENT_TEMPLATES live pre-Phase-C).
   - No file outside agentLoop/subAgent/etc. may host its own
     chat+executeTools+for-loop combination.
   - Exactly one definition of spawnSubAgent must exist.

WHY
- Widget gates: Tony asked for the agent to know what is on the canvas
  and add/remove widgets. Fast-paths in the gateway mean common phrases
  skip the LLM entirely (faster, cheaper, more reliable). UI-side gate
  handlers let the agent's emitted output drive canvas state directly.
- Spawn-path consolidation: the parallel mini-loop in swarm bypassed
  the governance overlay, so swarm-spawned sub-agents went off the
  books. Single canonical primitive means one place to instrument, one
  place to budget, one place to audit.
- Contract test: documentation rots. Greppable invariants do not.

TRADE-OFF
- swarm.runSubAgent's tool surface is now the spawnSubAgent allowlist
  (an array of tool names) rather than a pre-resolved tool definition
  array. The semantic is the same — both end up restricting the model's
  tool choice to the domain — but anything that introspected swarm's
  old tool-passing is no longer a thing.
- The architecture-contract test's 'You are X' regex is intentionally
  narrow (only matches sub-agent-style phrasings) so legitimate
  domain-specific chat prompts in goalProposer and reflection pass.
  Tightening it later if a new variant sneaks in is fine — it is a
  test, not a production gate.

FOLLOW-UP
- Phase C reorg of src/agent/ into 6 subdirs is queued as a dedicated
  worktree task (103 files, mechanical but extensive).
- See docs/SECURITY-AUDIT-2026-04-28.md for the npm-vuln punch list.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced widget management: users can now clear all canvas widgets, remove specific widgets by identifier, and update widget properties dynamically.

* **Documentation**
  * Added security audit snapshot documenting npm vulnerabilities and remediation plan.

* **Tests**
  * Added architecture compliance tests ensuring proper agent separation patterns and widget operation validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->