### PR TITLE
chore(release): v7.2.2 — security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v7.2.2 — 2026-08-07 — Security patch
+
+Dependency security updates closing 32 Dependabot alerts (12 High severity).
+No public API changes; no migration required.
+
+- **undici** 7.28.0→7.29.0, 8.7.0→8.10.0 — cross-user information disclosure
+  in shared caches, CRLF injection via blob `type`, cookie-attribute injection
+  in `setCookie()`, `no-cache`/`private` shared-cache bypass, retry-interceptor
+  response desynchronization
+- **next** 15.5.18→15.5.21 — SSRF in Server Actions on custom servers, SSRF via
+  rewrites, App Router Server Actions DoS, Turbopack middleware bypass, cache
+  confusion, image-optimizer DoS, Server Function endpoint disclosure
+- **axios** 1.17.0→1.18.1 — proxy-routing (CVE-2026-67320), `formDataToJSON`
+  recursion DoS, `maxBodyLength` bypass, `NO_PROXY` bypass
+- **fast-uri** 3.1.2→3.1.5 — host confusion via backslash authority, IDN
+  canonicalization
+- **brace-expansion** 1.1.14→1.1.16 — CVE-2026-13149 exponential-expansion DoS
+- **tar** 7.5.19→7.5.22 — unbounded recursion in `mapHas`/`filesFilter`
+- **nvidia/cuda** base image 13.3.0→13.3.1 (GPU Docker stage only)
+
+
 ## v7.2.1 — 2026-07-06 — Reliability Mode composes all four disciplines
 
 - **Discipline prompt (Organs 4+6)**: under `agent.reliabilityMode`, TITAN now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "titan-agent",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "titan-agent",
-      "version": "7.2.1",
+      "version": "7.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titan-agent",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "TITAN — the AI agent that provably teaches itself. TypeScript agent framework with replay-verified self-learned skills (Muscle Memory), one-minute Welcome Mode setup, a living desk with heartbeat/reminders/proactive memory, multi-agent orchestration, 36-provider routing, approval gates, receipts, evals, and a React Mission Control dashboard. Open-source, MIT.",
   "author": "Tony Elliott (https://github.com/Djtony707)",
   "repository": {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,7 +4,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 
-export const TITAN_VERSION = '7.2.1';
+export const TITAN_VERSION = '7.2.2';
 export const TITAN_CODENAME = 'Living Canvas';
 export const TITAN_NAME = 'TITAN';
 export const TITAN_FULL_NAME = 'The Intelligent Task Automation Network';

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -14,7 +14,7 @@ import { LLMProvider } from '../src/providers/base.js';
 // ─── Constants ──────────────────────────────────────────────────
 describe('Constants', () => {
     it('should have correct version', () => {
-        expect(TITAN_VERSION).toBe('7.2.1');
+        expect(TITAN_VERSION).toBe('7.2.2');
     });
 
     it('should have correct name', () => {

--- a/tests/mission-control.test.ts
+++ b/tests/mission-control.test.ts
@@ -232,7 +232,7 @@ vi.mock("../src/providers/router.js", () => ({
 vi.mock("../src/utils/updater.js", () => ({
   getUpdateInfo: vi
     .fn()
-    .mockResolvedValue({ current: "7.2.1", latest: "7.2.1", upToDate: true }),
+    .mockResolvedValue({ current: "7.2.2", latest: "7.2.2", upToDate: true }),
 }));
 
 vi.mock("../src/skills/registry.js", () => ({
@@ -385,7 +385,7 @@ describe("Mission Control v2", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.status).toBe("ok");
-      expect(body.version).toBe("7.2.1");
+      expect(body.version).toBe("7.2.2");
       expect(typeof body.uptime).toBe("number");
     });
 
@@ -393,7 +393,7 @@ describe("Mission Control v2", () => {
       const res = await fetch(`${BASE}/api/stats`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.version).toBe("7.2.1");
+      expect(body.version).toBe("7.2.2");
       expect(typeof body.uptime).toBe("number");
     });
   });
@@ -418,7 +418,7 @@ describe("Mission Control v2", () => {
       const res = await fetch(`${BASE}/api/update`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.current).toBe("7.2.1");
+      expect(body.current).toBe("7.2.2");
     });
   });
 


### PR DESCRIPTION
Version bump and changelog for the v7.2.2 security patch.

Closes 32 Dependabot alerts (12 High) via the dependency updates already merged to main: undici (#143), next (#134), axios (#130), fast-uri (#146), brace-expansion (#137), tar (#138), nvidia/cuda (#141).

No public API changes. No migration required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Released version 7.2.2 with security updates addressing multiple dependency vulnerabilities.
  * Includes fixes for high-severity issues affecting networking, web framework, HTTP client, archive handling, and container components.

* **Compatibility**
  * No public API changes or migration steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->